### PR TITLE
Add centralized prompt library index to /prompts

### DIFF
--- a/prompts/library.md
+++ b/prompts/library.md
@@ -1,0 +1,70 @@
+# 📚 Prompt Library for Legal Applications
+
+This document organizes and classifies legal prompts developed in this repository by category, format, and purpose. It serves as a quick reference and learning tool for legal professionals, researchers, and students.
+
+---
+
+## 📄 Document Review Prompts
+
+### 🔹 Early Termination Clauses (Lease)
+
+* **Prompt:** Identify and summarize early termination clauses in a commercial lease.
+* **File:** [`example_03_document_review.md`](./example_03_document_review.md)
+* **Format:** Bullet list + page reference + plain-language summary
+
+---
+
+## ⚖️ Legal Research Prompts
+
+### 🔹 Patent Infringement (U.S.)
+
+* **Prompt:** Analyze direct patent infringement under 35 U.S.C. § 271(a) with case references.
+* **File:** [`example_01_patent_prompt.md`](./example_01_patent_prompt.md)
+* **Format:** Formal analysis (3-paragraph legal memo)
+
+---
+
+## ✍️ Contract Drafting Prompts
+
+### 🔹 NDA for SaaS + Healthcare
+
+* **Prompt:** Draft a mutual NDA including HIPAA exclusions and New York governing law.
+* **File:** [`example_02_confidentiality_prompt.md`](./example_02_confidentiality_prompt.md)
+* **Format:** Contract structure outline (section-based)
+
+---
+
+## 🧪 Comparative Prompting
+
+### 🔹 Strong vs Weak Prompt Examples
+
+* **Prompt:** Side-by-side comparison of vague vs specific prompts in multiple domains.
+* **File:** [`comparison_weak_vs_strong_prompts.md`](./comparison_weak_vs_strong_prompts.md)
+* **Format:** Inline examples + commentary
+
+---
+
+## 🧾 Prompt Structure Types
+
+| Type                  | Description                                         | Example Prompt File                    |
+| --------------------- | --------------------------------------------------- | -------------------------------------- |
+| Role-Based Prompt     | Assigns the AI a legal persona or professional role | `example_02_confidentiality_prompt.md` |
+| Chain-of-Thought      | Breaks task into logical steps                      | `example_03_document_review.md`        |
+| Format-Constrained    | Specifies bullet list, table, memo, etc.            | All examples                           |
+| Jurisdiction-Specific | Anchors the prompt in legal system or time frame    | `example_01_patent_prompt.md`          |
+| Comparative           | Contrasts vague and optimized prompts               | `comparison_weak_vs_strong_prompts.md` |
+
+---
+
+## 🔄 Coming Soon
+
+* Prompts in Spanish and multilingual format
+* Prompt patterns for litigation prep and statutory interpretation
+* IRAC-based prompt templates
+* Compliance checklists and regulatory parsing
+
+> 📬 Want to contribute? Submit your own prompt via pull request or fork this file to extend the library.
+
+---
+
+*Maintained by Enrique Arce Núñez · CC BY 4.0 License*


### PR DESCRIPTION
This pull request introduces a centralized prompt index in `prompts/library.md` to help users navigate and reuse examples effectively. It includes links to each existing example and brief descriptions of their purpose. This improves usability and supports further contributions to the repository.
